### PR TITLE
Normalization and Sanitation Transformers

### DIFF
--- a/src/SVGPathData.js
+++ b/src/SVGPathData.js
@@ -21,6 +21,18 @@ SVGPathData.prototype.toRel = function() {
   return this.transform(SVGPathData.Transformer.TO_REL);
 };
 
+SVGPathData.prototype.normalizeHVZ = function() {
+  return this.transform(SVGPathData.Transformer.NORMALIZE_HVZ);
+};
+
+SVGPathData.prototype.normalizeST = function() {
+  return this.transform(SVGPathData.Transformer.NORMALIZE_ST);
+};
+
+SVGPathData.prototype.sanitize = function() {
+  return this.transform(SVGPathData.Transformer.SANITIZE);
+};
+
 SVGPathData.prototype.translate = function() {
   return this.transform.apply(this, [SVGPathData.Transformer.TRANSLATE].concat(
     [].slice.call(arguments, 0)));
@@ -137,6 +149,7 @@ SVGPathData.SMOOTH_CURVE_TO = 64;
 SVGPathData.QUAD_TO = 128;
 SVGPathData.SMOOTH_QUAD_TO = 256;
 SVGPathData.ARC = 512;
+SVGPathData.LINE_COMMANDS = SVGPathData.LINE_TO | SVGPathData.HORIZ_LINE_TO | SVGPathData.VERT_LINE_TO
 SVGPathData.DRAWING_COMMANDS =
   SVGPathData.HORIZ_LINE_TO | SVGPathData.VERT_LINE_TO | SVGPathData.LINE_TO |
   SVGPathData.CURVE_TO | SVGPathData.SMOOTH_CURVE_TO | SVGPathData.QUAD_TO |

--- a/tests/normalize_curves.mocha.js
+++ b/tests/normalize_curves.mocha.js
@@ -1,0 +1,35 @@
+var assert = (
+    global && global.chai
+    ? global.chai.assert
+    : require('chai').assert
+  )
+  , SVGPathData = (
+    global && global.SVGPathData
+    ? global.SVGPathData
+    : require(__dirname + '/../src/SVGPathData.js')
+  )
+;
+
+describe("normalization of curves", function() {
+
+  it("should ignore everything which isn't S s T t", function() {
+    assert.equal(new SVGPathData(
+      'm20,30c0 0 10 20 15 30q10 20 15 30h10v10a10 10 5 1 0 10 10z'
+      ).normalizeST().encode(),
+      new SVGPathData('m20,30c0 0 10 20 15 30q10 20 15 30h10v10a10 10 5 1 0 10 10z').encode());
+  });
+
+  it("should take the previous point as the curve parameter if the previous curve isn't of the same type", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 h 100 s 10 20 15 30 t 20 15'
+      ).normalizeST().encode(),
+      new SVGPathData('M 10 10 h 100 c 0 0 10 20 15 30 q 0 0 20 15').encode());
+  });
+
+  it("should mirror the previous control point", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 s 10 20 15 30 S 90 80 100 100'
+      ).normalizeST().encode(),
+      new SVGPathData('M 10 10 c 0 0 10 20 15 30 C 30 50 90 80 100 100').encode());
+  });
+});

--- a/tests/normalize_hvz.mocha.js
+++ b/tests/normalize_hvz.mocha.js
@@ -1,0 +1,36 @@
+var assert = (
+    global && global.chai
+    ? global.chai.assert
+    : require('chai').assert
+  )
+  , SVGPathData = (
+    global && global.SVGPathData
+    ? global.SVGPathData
+    : require(__dirname + '/../src/SVGPathData.js')
+  )
+;
+
+describe("HVZA normalization", function() {
+
+  // currently z/Z is always absolute
+  it("should tranform relative h v z", function() {
+    assert.equal(new SVGPathData(
+      'm 10 10 h 100 v 100 z'
+      ).normalizeHVZ().encode(),
+      new SVGPathData('m 10 10 l 100 0 l 0 100 L 10 10').encode());
+  });
+
+  it("should tranform absolute h v z", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 H 100 V 100 Z'
+      ).normalizeHVZ().encode(),
+      new SVGPathData('M 10 10 L 100 10 L 100 100 L 10 10').encode());
+  });
+
+  it("should tranform degenerate arcs", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 A 0 10 0 0 0 100 100 a 20 0 0 0 0 20 0'
+      ).normalizeHVZ().encode(),
+      new SVGPathData('M 10 10 L 100 100 l 20 0').encode());
+  });
+});

--- a/tests/sanitize.mocha.js
+++ b/tests/sanitize.mocha.js
@@ -1,0 +1,57 @@
+var assert = (
+    global && global.chai
+    ? global.chai.assert
+    : require('chai').assert
+  )
+  , SVGPathData = (
+    global && global.SVGPathData
+    ? global.SVGPathData
+    : require(__dirname + '/../src/SVGPathData.js')
+  )
+;
+
+describe("normalization of curves", function() {
+
+  it("should clear zero length line segments", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 h 0 h 10 H 20 H 30 v 0 v 10 V 20 V 30 l 0 0 l 10 10 L 40 40 L 50 50'
+      ).sanitize().encode(),
+      new SVGPathData('M 10 10 h 10 H 30 v 10 V 30 l 10 10 L 50 50').encode());
+  });
+
+  it("should clear zero length quadratic curves", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 t 0 0 t 10 10 t 0 0 t 0 0'
+      ).sanitize().encode(),
+      new SVGPathData('M 10 10 t 10 10 t 0 0 t 0 0').encode());
+  });
+
+  it("should clear zero length quadratic curves (absolute)", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 T 10 10 T 20 20 T 20 20 T 20 20'
+      ).sanitize().encode(),
+      new SVGPathData('M 10 10 T 20 20 T 20 20 T 20 20').encode());
+  });
+
+  it("should clear zero length cubic curves", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 C 10 10 10 10 10 10 c 0 0 0 0 0 0 S 10 10 10 10 s 0 0 0 0'
+      ).sanitize().encode(),
+      new SVGPathData('M 10 10').encode());
+  });
+
+  it("should correctly handle first control point from smooth curve", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 s 10 10 20 10 s 0 0 0 0'
+      ).sanitize().encode(),
+      new SVGPathData('M 10 10 s 10 10 20 10 s 0 0 0 0').encode());
+  });
+
+  it("should remove 0-length Zz", function() {
+    assert.equal(new SVGPathData(
+      'M 10 10 h 10 h -10 Z'
+      ).sanitize().encode(),
+      new SVGPathData('M 10 10 h 10 h -10').encode());
+  });
+
+});


### PR DESCRIPTION
Added transformers:
SVGPathDataTransformer.NORMALIZE_HVZ (converts HVZ and A with 0 == rx or 0 == ry to L (relative or not depending on original command, except for Zz where the information is currently lost, always results in L)
SVGPathDataTransformer.NORMALIZE_ST (converts SsTt to CcQq respectively)
SVGPathDataTransformer.SANITIZE (removes 0-length HVZCSQTZhvzcsqtz, A missing, might add later)

Added methods:
SVGPathData.prototype.normalizeHVZ
SVGPathData.prototype.normalizeST
SVGPathData.prototype.sanitize

Added tests:
tests/normalize_curves.mocha.js
tests/normalize_hvz.mocha.js
tests/sanitize.mocha.js